### PR TITLE
Fix tweet shortcode to display correctly.

### DIFF
--- a/content/posts/category/sub-category/rich-content/index.md
+++ b/content/posts/category/sub-category/rich-content/index.md
@@ -25,7 +25,7 @@ This sample post tests the followings:
 
 ### Tweet Sample
 
-{{/*< twitter 1085870671291310081 >*/}}
+{{< tweet 1085870671291310081 >}}
 
 {{< vs >}}
 


### PR DESCRIPTION
Current example site [rich content page](https://hugo-toha.github.io/posts/category/sub-category/rich-content/#tweet-sample) does not display tweets properly.

<img width="1272" alt="Screen Shot 2021-07-09 at 1 12 40 PM" src="https://user-images.githubusercontent.com/5226765/125131437-a1049080-e0b7-11eb-9956-dee8af427fcb.png">

Per [hugo doc site](https://gohugo.io/content-management/shortcodes/#example-tweet-input) shortcode should be tweet and escape characters should not be present.

