### PR TITLE
fix: update action run enviroment

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-lates
     steps:
     # checkout to the commit that has been pushed
     - uses: actions/checkout@v3


### PR DESCRIPTION
github action fail because using outdated ubuntu version. Updating run environment to latest