### PR TITLE
added gitlab-ci.yml for gitlab pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+image: registry.gitlab.com/pages/hugo/hugo_extended:latest
+
+default:
+  before_script:
+    - apk add --update --no-cache git go nodejs npm
+    - hugo mod tidy
+    - hugo mod npm pack
+    - npm install 
+
+test:
+  script:
+    - hugo
+  rules:
+    - if: $CI_COMMIT_REF_NAME != $CI_DEFAULT_BRANCH
+
+pages:
+  script:
+    - hugo
+  artifacts:
+    paths:
+      - public
+  rules:
+    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
+


### PR DESCRIPTION
This allows people to quickly deploy their website to Gitlab as well as Github. This is pulled from my repo which is hosted on Gitlab pages and is working smoothly.