### PR TITLE
Add researchgate to contactInfo and socialLinks

### DIFF
--- a/data/en/author.yaml
+++ b/data/en/author.yaml
@@ -10,6 +10,7 @@ contactInfo:
   phone: "+0123456789"
   github: johndoe
   linkedin: johndoe
+  researchgate: john-doe
 
 # some summary about what you do
 summary:

--- a/data/en/sections/about.yaml
+++ b/data/en/sections/about.yaml
@@ -53,6 +53,10 @@ socialLinks:
   url: "#"
   rel: "me noopener"
 
+- name: ResearchGate
+  icon: "fab fa-researchgate"
+  url: "https://www.researchgate.net/profile/john-doe"
+
 # You can put custom buttons to link your relevant resources.
 # For example, you can put link for your resume.
 resourceLinks:


### PR DESCRIPTION
ResearchGate is a platform used by scientists/developers/... to  exchange papers as well as a professional profile.

Support for ResearchGate was added in Toha in [PR 864](https://github.com/hugo-toha/toha/pull/864).