### PR TITLE
fix a typo in education.yaml

### DIFF
--- a/data/en/sections/education.yaml
+++ b/data/en/sections/education.yaml
@@ -70,7 +70,7 @@ degrees:
   - Vestibulum consectetur lorem justo, at laoreet lorem feugiat et.
   - Duis sed massa feugiat, ornare justo et, aliquam est.
   - Pellentesque ut fringilla magna.
-  custonSections: #(optional)
+  customSections: #(optional)
     - name: Thesis
       content: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     - name: Supervisor


### PR DESCRIPTION
Fixed a typo in `data/en/sections/education.yaml` by changing `custonSections` to `customSections`. This correction resolved an issue where a section of the education card was not rendering properly.