### PR TITLE
Add Nix flake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 resources/*
 node_modules/*
 public/*
+result
+build/*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742512142,
+        "narHash": "sha256-8XfURTDxOm6+33swQJu/hx6xw1Tznl8vJJN5HwVqckg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7105ae3957700a9646cc4b766f5815b23ed0c682",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "toha": "toha"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "toha": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1738875668,
+        "narHash": "sha256-B24ft1uD05DcN1gipwDLXcCceWNkiJL/UA7iTGXHgHA=",
+        "owner": "hugo-toha",
+        "repo": "toha",
+        "rev": "aa91957832e73326f6ea3f320386ce8773696d49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hugo-toha",
+        "ref": "v4.8.0",
+        "repo": "toha",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,152 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    toha = {
+      flake = false;
+      url = "github:hugo-toha/toha/v4.8.0";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgs-unstable,
+      flake-utils,
+      toha,
+    }:
+    let
+      name = "hugo-toha.github.io";
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
+
+        go = pkgs-unstable.go;
+        hugo = pkgs-unstable.hugo;
+
+        website-src = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
+
+        website-descr = {
+          inherit name;
+
+          nativeBuildInputs = [
+            go
+            hugo
+          ];
+
+          npmDepsHash = "sha256-/BOgQY41ahnONSJNQL39W2zKrzO7dT/7HRD1mOJ/CQI=";
+
+          src = website-src;
+
+          postPatch =
+            let
+              before_patch = ''
+                // replace(
+                //     github.com/hugo-toha/toha/v4 => ../toha
+                // )
+              '';
+              after_patch = ''
+                replace(
+                    github.com/hugo-toha/toha/v4 => ${toha}
+                )
+              '';
+            in
+            ''
+              substituteInPlace go.mod --replace-fail "${before_patch}" "${after_patch}"
+              find . -type f -name "*.md" | xargs sed -i 's/{{<[[:space:]]*tweet[[:space:][:alnum:]="]*>}}/TWEETS DISABLED BY NIX PATCH/g'
+            '';
+
+          buildPhase = ''
+            runHook preBuild
+            ${hugo}/bin/hugo
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out
+            cp -r public/* $out/
+            runHook postInstall
+          '';
+        };
+
+        website = pkgs.buildNpmPackage website-descr;
+
+        website-src-and-deps = pkgs.buildNpmPackage (
+          website-descr
+          // {
+            name = "${website-descr.name}-src-and-deps";
+
+            buildPhase = ''
+              runHook preBuild
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out
+              cp -r ./* $out/
+              runHook postInstall
+            '';
+          }
+        );
+
+        hugo-in-build = pkgs.writeShellApplication {
+          name = "hugo";
+          runtimeInputs =
+            [ website-src-and-deps ]
+            ++ website.nativeBuildInputs
+            ++ (with pkgs; [
+              git
+              rsync
+            ]);
+          text = ''
+            echo "You are running a wrapper around hugo that updates the content of ./build/ and runs it there."
+            mkdir -p build
+            # Copy from Nix store because hugo requires some of the files to be editable
+            rsync --recursive --copy-links --copy-dirlinks --chmod=777 --delete ${website-src-and-deps}/ build/
+            # Hard link some files so that hugo can automatically rebuilt when they change
+            find ./*.json ./*.mod ./*.yaml ./archetypes ./assets ./content ./data ./static -print0 | xargs -0 -I file sh -c "test -f file && test -f build/file && cmp --silent file build/file && cp -prfl file build/file || true"
+            # shellcheck disable=SC2048,SC2086
+            (cd "build/"; hugo $*)
+          '';
+        };
+
+        hugo-in-build-defaults-to-server = pkgs.writeShellApplication {
+          name = "hugo";
+          runtimeInputs = [ hugo-in-build ];
+          text = ''
+            if [ "$#" -ne 0 ]; then
+              hugo "$*"
+            else
+              hugo server
+            fi
+          '';
+        };
+      in
+
+      rec {
+        packages = {
+          "${name}" = website;
+          default = website;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            go
+            hugo-in-build
+          ];
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${hugo-in-build-defaults-to-server}/bin/hugo";
+        };
+      }
+    );
+}


### PR DESCRIPTION
This commit adds a Nix flake, that should allow running the website on any system with `Nix`. One can use it to:
- build the website via `nix build`;
- get a shell with `go` and `hugo`¹ via `nix develop`;
- run the equivalent of `hugo server` via `nix run`.

Uses of `{{< tweet ... >}}` are removed because otherwise it causes an error when running `nix build`.

¹Since `hugo` needs some file to be editable (and files in the Nix store are not), this is a wrapper around `hugo` that places the source and all relevant dependencies in `./build/` and then runs `hugo` there. The source files that have not been changed by the derivation are hardlinked to allow `hugo` to detect changes and automatically rebuilt.