### PR TITLE
Update hugo.yaml

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,3 +1,4 @@
+# ⚠️ If hosting under a repo path, use full URL (e.g. https://<github_username>.github.io/<repo_name>) or images won’t display correctly
 baseURL: https://hugo-toha.github.io
 
 languageCode: bn


### PR DESCRIPTION
It clarifies that when deploying to GitHub Pages under a repository path (instead of the root), the baseURL must include the full repo path (e.g. https://<github_username>.github.io/<repo_name>). Without this adjustment, images may not display correctly.

Why
To prevent broken image links when the site is published on GitHub Pages in a non-root location.